### PR TITLE
Print an error message when can't write to file

### DIFF
--- a/bp_v8/bp_v8.ino
+++ b/bp_v8/bp_v8.ino
@@ -201,6 +201,8 @@ void setup() {
         
         // close the file:
         myFile.close();
+    } else {
+        Serial.println(F("Could not write to file."));
     }
 
     // print the data to debug output as well


### PR DESCRIPTION
If we can't write to the file to write the initial header than print out to the serial console to make the log output clearer.